### PR TITLE
Keep junk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ trainingset/*
 training_data/*
 tmp/*
 .ipynb_checkpoints/*
+*.wav
+*.mp4
+*.mkv

--- a/simple_ehm-runnable.py
+++ b/simple_ehm-runnable.py
@@ -6,6 +6,7 @@ import os
 import io
 import pathlib
 import argparse
+import signal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -41,6 +42,7 @@ parser.add_argument("--generate-training-data", default=False, action='store_tru
 parser.add_argument("--srt", default=False, action='store_true', help="generate subtitle track for easier accuracy evaluation")
 parser.add_argument("--keep", nargs="+", default=["speech"], help="space separated tags to to be kept in the final video. Eg: ehm silence. Default: speech")
 parser.add_argument("--output", type=str, default="", help="Output video name")
+parser.add_argument("--keep-junk", default=False,action="store_true", help="keeps tmp files")
 
 args = parser.parse_args()
 video_path = args.filename
@@ -56,6 +58,23 @@ trash = set()
 
 cuts = []       # edits for ffmpeg to split
 mergelist = []  # files for ffmpeg to merge back
+
+# ctrl+c handler
+def signal_handler(sig, frame):
+    try:
+        filename, file_extension = os.path.splitext(video_path)
+        if(not args.keep_junk):
+            os.remove(f'{filename}.wav')
+            for file in os.listdir("tmp"):
+                os.remove("tmp/"+file)
+
+    except Exception as e:
+        pass
+
+    exit()
+
+signal.signal(signal.SIGINT, signal_handler)
+
 
 def plot_spectrogram(spectrogram, ax):
   # Convert to frequencies to log scale and transpose so that the time is
@@ -298,7 +317,11 @@ if __name__ == '__main__':
     analyze_track(model, waveform, sample_rate)
     cut_and_merge(video_path[:-4])
     
-    os.remove(wav_path)
+	# removes tmp files
+    if(not args.keep_junk):
+        os.remove(wav_path)
+        for file in os.listdir("tmp"):
+            os.remove("tmp/"+file)
 
     print("\nFATTO!")
     for k, v in zip(_perf.keys(), _perf.values()):


### PR DESCRIPTION
Adesso in automatico i file in tmp e il file wav vengono eliminati, anche in seguito a una chiusura forzata mediante `ctrl+c`. Per fare in modo che questi rimangano può essere fornito il parametro `--keep-junk` a fine di debug.