### PR TITLE
Video cut fix

### DIFF
--- a/simple_ehm-runnable.py
+++ b/simple_ehm-runnable.py
@@ -143,7 +143,7 @@ def generate_tdata(ss, to, count, label):
 
 def generate_cut(ss, to, count):
     out_name = str(count) + video_path[-4:]
-    cuts.append(["ffmpeg", "-hide_banner", "-loglevel", "error", "-ss", ss ,"-i", video_path,  "-to", to, "-copyts"])
+    cuts.append(["ffmpeg", "-hide_banner", "-loglevel", "error", "-ss", ss ,"-i", video_path,  "-ss", ss,  "-to", to, "-copyts"])
     if args.crf > 0:
         cuts[-1].extend(["-crf", str(args.crf)])
     if args.fps > 0:


### PR DESCRIPTION
# Fast seeking
Ho notato che in alcuni file quello che succede è che il timestamp del video è sballato, ciò è dovuto a un errore in fase di taglio. Leggendo su internet ponendo il parametro `-ss` prima del `-i` quello che succede è un `fast seeking`, ovvero ffmpeg non esegue il taglio esattamente dove vorremmo ma in un punto vicino. Ciò significa che se casualmente eseguiamo dei tagli "tra frame e frame" lui approssimerà il tempo, ma questo poi va in conflitto a causa del `-copyts` perchè quando ricolleghiamo tutto ci sono pezzi di video con timestamp che si sovrappongono (perchè abbiamo tagliato in modo non accurato).

# Accurate seeking
Se invece poniamo `-ss` dopo -i abbiamo un accurate seeking, ovvero un taglio preciso come vogliamo noi, ma con la differenza è che tale precisione comporta un aumento enorme in termini di tempo dovendo analizzare la traccia cercando il punto esatto.

# Fast and accurate seeking
Come risolviamo? Con il fast and accurate seeking: ci posizioniamo in una posizione "sicura" (denomanita `safe`) in modo non accurato, almeno ffmpeg sa che non è importante il punto esatto e può approssimare senza problemi (io mi posiziono 1 secondo prima del taglio effettivo). Da li in poi eseguiamo un taglio accurato (più lento) ma solo sul pezzo che ci interessa! In questo modo siamo molto più veloci di un taglio normale (avendo la prima parte approssimata) ma otteniamo la correttezza esatta nel taglio senza sovrapposizioni di timestamp (grazie al taglio accurato).


Fonte: https://superuser.com/questions/138331/using-ffmpeg-to-cut-up-video

# Statistiche Merge and Cut
Questi test sono fatti su un file mp4 di 90 minuti
- **Fast seeking (versione base):** 10 minuti (ma non funzionante, il file pensa di durare 22 ore)
- **Accurate seeking (solo per test):** +50 minuti
- **Fast and accurate seeking (pr):** 13 minuti