### PR TITLE
Add Dockerfile to run simple-ehm in a dockerized environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9-slim
+RUN apt update
+RUN apt install libgl1-mesa-glx -y
+RUN apt install libglib2.0-0 -y
+RUN apt install ffmpeg -y
+RUN mkdir /simple_ehm
+WORKDIR /simple_ehm
+ADD . .
+RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This will generate a subtitle track (`.srt`) for debugging and the output video 
 For more info read the help:
 `./simple_emh-runnable.py --help`
 
+You can also run simple-ehm in a dockerized environment. Simply use the Dockerfile to build the image then, instead of
+using `./simple_ehm-runnable.py` use `./convert.sh`
+
 # Contributing to the model
 There are two ways you can contribute to the model:
 
@@ -35,6 +38,9 @@ Questo genererò una traccia di sottotitoli (`.srt`) per fini diagnostici e il v
 
 Per maggiori informazioni sui parametri accettati, leggi la guida:
 `./simple_emh-runnable.py --help`
+
+Puoi anche utilizzare simple-ehm in un ambiente dockerizzato, per fare ciò, dove useresti `./simple_ehm-runnable.py`
+utilizza invece `./convert.sh` (N.B. per usare `./convert.sh` i file devono essere spostati prima in questa cartella)
 
 # Contribuire al modello
 Ci sono due modi in cui puoi contribuire al modello:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This will generate a subtitle track (`.srt`) for debugging and the output video 
 For more info read the help:
 `./simple_emh-runnable.py --help`
 
-You can also run simple-ehm in a dockerized environment. Simply use the Dockerfile to build the image then, instead of
-using `./simple_ehm-runnable.py` use `./convert.sh`
+You can also run simple-ehm in a dockerized environment. Build the image using `docker build -t simple .` then, instead
+of using `./simple_ehm-runnable.py` use `./convert.sh`
 
 # Contributing to the model
 There are two ways you can contribute to the model:
@@ -39,8 +39,9 @@ Questo genererò una traccia di sottotitoli (`.srt`) per fini diagnostici e il v
 Per maggiori informazioni sui parametri accettati, leggi la guida:
 `./simple_emh-runnable.py --help`
 
-Puoi anche utilizzare simple-ehm in un ambiente dockerizzato, per fare ciò, dove useresti `./simple_ehm-runnable.py`
-utilizza invece `./convert.sh` (N.B. per usare `./convert.sh` i file devono essere spostati prima in questa cartella)
+Puoi anche utilizzare simple-ehm in un ambiente dockerizzato, per fare ciò crea l'immagine `docker build -t simple .`, e
+dove useresti `./simple_ehm-runnable.py` utilizza invece `./convert.sh` (N.B. per usare `./convert.sh` i file devono
+essere spostati prima in questa cartella)
 
 # Contribuire al modello
 Ci sono due modi in cui puoi contribuire al modello:

--- a/convert.sh
+++ b/convert.sh
@@ -1,0 +1,1 @@
+docker run --rm -v $PWD:/simple_ehm simple python ./simple_ehm-runnable.py $1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+tensorflow==2.6.2
 matplotlib
 seaborn
-tensorflow==2.6.2
 tqdm
 psutil
 opencv-python
+protobuf==3.20.0


### PR DESCRIPTION
Because in `requirements.txt` tensorflow is set to version 2.6.2, simple-ehm can't be used on python 3.10.x or later. And since most people wouldn't want to install a 2nd version of python on their system, running it within Docker could be a solution.