### PR TITLE
Fixed version of protobuf dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ seaborn
 tqdm
 psutil
 opencv-python
-protobuf==3.20.0
+protobuf==3.20.3


### PR DESCRIPTION
Fixed pip3 installation error:
ERROR: Cannot install -r requirements.txt (line 1) and protobuf==3.20.0 because these package versions have conflicting dependencies.